### PR TITLE
Adiocionado reload, dependencias e .gitignore atualizados, e bug da t…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 dist/
+node_modules/
+eng.treineddata
+package-lock.json
+eng.traineddata
+por.traineddata

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "license": "ISC",
     "devDependencies": {
       "electron": "^28.1.0",
-      "electron-builder": "^24.9.1"
+      "electron-builder": "^24.9.1",
+      "electron-reload": "^2.0.0-alpha.1"
     },
     "dependencies": {
       "tesseract.js": "^5.0.4",

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,26 @@
-const { app, BrowserWindow, Tray, Menu, globalShortcut, ipcMain, desktopCapturer } = require('electron');
+const { app } = require('electron');
+const gotTheLock = app.requestSingleInstanceLock();
+
+if (!gotTheLock) {
+  app.quit();
+  process.exit(0);
+} else {
+  app.on('second-instance', () => {
+    if (mainWindow) {
+      if (mainWindow.isMinimized()) mainWindow.restore();
+      mainWindow.focus();
+    }
+  });
+}
+
+require('electron-reload')(
+  [__dirname, require('path').join(__dirname, '..', 'public')],
+  {
+    electron: require(require('path').join(__dirname, '..', 'node_modules', 'electron'))
+  }
+);
+
+const { BrowserWindow, Tray, Menu, globalShortcut, ipcMain, desktopCapturer } = require('electron');
 const path = require('path');
 const fs = require('fs');
 const { createWorker } = require('tesseract.js');
@@ -565,8 +587,6 @@ async function requestApiKey() {
       resizable: false,
       minimizable: false,
       maximizable: false,
-      parent: mainWindow,
-      modal: true,
       webPreferences: {
         nodeIntegration: true,
         contextIsolation: false


### PR DESCRIPTION
📌 Pull Request

 Description

- Added automatic reloading to help with development.
- Updated root .gitignore file to include automatically generated files and folders.
- Fixed bug that caused the API key window to flash on the main screen when closed.

-

## 🔗 Related Issues
-None
- Closes #

## ✅ Checklist
- [X] I have tested it locally and it is working as expected
- [X] I have added/updated documentation (if necessary)
- [X] I have not broken any existing functionality
- [X] This PR is ready for review

## 🧪 How to Test
<!-- Clear instructions for testing this change -->

1. To test the reload, install the dependencies using the 'npm install' command, run the software using the 'npm start' command, make changes to the code and check to see if the update was applied.
2. To test the screen bug, in the previous version when the API key screen was open and the index window was also open, when closing the API key screen the index screen would flash, now when opening and closing the API key screen with the index window open the same bug does not occur.

## 📸 Screenshots (optional)
- None